### PR TITLE
feat(jfoliveira): add Devopness - DevOps for AI Agents & Humans

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -20,7 +20,7 @@
 
 > [!NOTE]
 >
-> - <sup>1</sup> Por ativo, o projeto precisa estar pronto para receber Issues ou Pull Requests de possíveis contribuidores e estar aberto a discussões.
+> - <sup>1</sup> Por ativo, o projeto precisa estar pronto para receber Issues ou Pull Requests de possíveis colaboradores e estar aberto a discussões.
 > - <sup>2</sup> "Aceitar" é diferente de "mesclar". Se o projeto é feito para a comunidade _open source_, ele deve estar aberto para debater ideias que usuários proponham e corrigir _bugs_ reportados, por exemplo.
 > - <sup>3</sup> O **GitHub** busca pelo arquivo `LICENSE` e também por arquivos que comecem por `LICENSE-___`, ambos no diretório raiz do repositório. Caso o **GitHub** não encontre a licença, o projeto irá falhar nos testes automatizados.
 

--- a/docs/SCORE.md
+++ b/docs/SCORE.md
@@ -17,11 +17,11 @@ Por exemplo, um projeto com poucas estrelas, mas que tenha contribuições de ou
 
 Projeto com uma comunidade forte:
 
-- Com **15** contribuidores, **0** instalações ou downloads, **20** forks, **55** estrelas, **5** issues abertas e **45** issues fechadas conseguiria quebrar a barreira dos **200** pontos.
+- Com **15** colaboradores, **0** instalações ou downloads, **20** forks, **55** estrelas, **5** issues abertas e **45** issues fechadas conseguiria quebrar a barreira dos **200** pontos.
 
 Projeto com alto impacto, mas baixa popularidade:
 
-- Com **6** contribuidores, **20.000** instalações ou downloads mensais, **3** forks, **16** estrelas, **0** issues abertas, **28** issues fechadas e **200** dependências diretas do repositório conseguiria quebrar a barreira dos **200** pontos.
+- Com **6** colaboradores, **20.000** instalações ou downloads mensais, **3** forks, **16** estrelas, **0** issues abertas, **28** issues fechadas e **200** dependências diretas do repositório conseguiria quebrar a barreira dos **200** pontos.
 
 **Como é possível um projeto ter tantos downloads e não ser popular?**
 
@@ -43,9 +43,9 @@ Para um projeto que dependa exclusivamente da popularidade, ele precisaria obter
 
 <br />
 
-As pontuações por senso de comunidade envolvem números de contribuidores com _commits_ na _branch_ principal do repositório e também através da intenção de contribuição _(forks)_:
+As pontuações por senso de comunidade envolvem números de colaboradores com _commits_ na _branch_ principal do repositório e também através da intenção de contribuição _(forks)_:
 
-- Cada contribuidor com _commits_ na _branch_ principal equivale a **5** pontos.
+- Cada colaborador com _commits_ na _branch_ principal equivale a **5** pontos.
   - Atualmente, essa conta também inclui _bots_, não por intenção, mas por limitação de automação.
 - Cada intenção de contribuição _(forks)_ equivalem a **2** pontos.
 - É obrigatório que o projeto tenha uma licença transparente e identificada pelo **GitHub**.

--- a/schemas/projects.json
+++ b/schemas/projects.json
@@ -70,6 +70,7 @@
                 "app",
                 "database",
                 "ci",
+                "cloud",
                 "devops",
                 "language",
                 "performance",

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -211,7 +211,7 @@ export const Project: FC<ProcessedProject> = ({
                   </tr>
 
                   <tr>
-                    <td>Contribuidores:</td>
+                    <td>Colaboradores:</td>
                     <td>
                       <SafeLink to={`${url}/graphs/contributors`}>
                         <HeartHandshake />

--- a/src/configs/categories.ts
+++ b/src/configs/categories.ts
@@ -8,6 +8,7 @@ export const categories = Object.freeze({
   app: 'Apps, Plataformas e Softwares',
   database: 'Banco de Dados',
   ci: 'CI/CD',
+  cloud: 'Cloud',
   devops: 'DevOps',
   language: 'Linguagem de Programação',
   performance: 'Performance',

--- a/src/pages/_dynamic/maintainer/_ld/faqs.ts
+++ b/src/pages/_dynamic/maintainer/_ld/faqs.ts
@@ -48,7 +48,7 @@ export const ldFaqs = (options: Props) => {
             ? [
                 {
                   name: `Quem criou o ${project.name}?`,
-                  text: `${project.name} foi criado por ${name}, contribuinte brasileiro ativo da comunidade open source.`,
+                  text: `${project.name} foi criado por ${name}, colaborador brasileiro ativo da comunidade open source.`,
                 },
               ]
             : []),

--- a/src/pages/_dynamic/maintainer/_project.tsx
+++ b/src/pages/_dynamic/maintainer/_project.tsx
@@ -107,7 +107,7 @@ export const Project: FC<Props> = (project) => {
         </p>
         <p>
           — O repositório do projeto conta com{' '}
-          <strong>{stats.contributors.label}</strong> contribuidor
+          <strong>{stats.contributors.label}</strong> colaborador
           {stats.contributors.value > 1 && 'es'}
           {stats.repositoryDependents.value > 0 && (
             <>

--- a/src/pages/calculator.tsx
+++ b/src/pages/calculator.tsx
@@ -344,7 +344,7 @@ export default (): ReactNode => {
                   <table>
                     <tbody>
                       <tr>
-                        <td>Contribuidores</td>
+                        <td>Colaboradores</td>
                         <td>
                           <HeartHandshake />
                           {stats?.contributors?.label || 0}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -347,7 +347,7 @@ export default (): ReactNode => {
                   Como um projeto aberto e criado pela comunidade para a
                   comunidade, todos os{' '}
                   <SafeLink to='https://github.com/wellwelwel/awesomeyou/graphs/contributors'>
-                    <strong>contribuidores</strong>
+                    <strong>colaboradores</strong>
                   </SafeLink>{' '}
                   fazem parte do projeto 🤝
                 </p>

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -67,7 +67,7 @@ const Footer = (): ReactNode => {
           </p>
           <p>
             Os dados vêm de APIs públicas e das próprias informações fornecidas
-            pelos contribuidores ao incluirem projetos e mantenedores.
+            pelos colaboradores ao incluirem projetos e mantenedores.
           </p>
           <p>
             Você pode encontrar nosso código fonte e contribuir através do{' '}

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -3,7 +3,7 @@
   "projects": [
     {
       "repository": "https://github.com/devopness/devopness",
-      "description": "BuildCLI is a command-line interface (CLI) tool for managing and automating common tasks in Java project development.",
+      "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀",
       "madeInBrazil": true,
       "isAuthor": true,
       "message": "Deixe uma estrelinha ⭐ e envie PRs para o repo do Devopness :-). Contrataremos freelas (e equipe permanente 🤞🏽) com prioridade para quem já tem seu nome aqui https://github.com/devopness/devopness/graphs/contributors :-)",

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -3,6 +3,7 @@
   "projects": [
     {
       "repository": "https://github.com/devopness/devopness",
+      "name": "Devopness",
       "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀 https://www.youtube.com/@devopness/videos",
       "madeInBrazil": true,
       "isAuthor": true,

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../../schemas/projects.json",
+  "projects": [
+    {
+      "repository": "https://github.com/devopness/devopness",
+      "description": "BuildCLI is a command-line interface (CLI) tool for managing and automating common tasks in Java project development.",
+      "madeInBrazil": true,
+      "isAuthor": true,
+      "message": "Deixe uma estrelinha ⭐ e envie PRs para o repo do Devopness :-). Contrataremos freelas (e equipe permanente 🤞🏽) com prioridade para quem já tem seu nome aqui https://github.com/devopness/devopness/graphs/contributors :-)",
+      "languages": [
+        "javascript",
+        "typescript",
+        "python",
+        "ruby",
+        "shell"
+      ],
+      "categories": [
+        "ai",
+        "api",
+        "career",
+        "ci",
+        "cli",
+        "cloud",
+        "devops",
+        "git",
+        "productivity",
+        "tool"
+      ]
+    }
+  ]
+}

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -3,20 +3,12 @@
   "projects": [
     {
       "repository": "https://github.com/devopness/devopness",
-      "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀",
+      "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀 https://www.youtube.com/@devopness/videos",
       "madeInBrazil": true,
       "isAuthor": true,
-      "message": "Deixe-nos uma estrelinha ⭐ e PRs são bem-vindas :-). Veja o produto em ação em https://www.youtube.com/@devopness/videos",
-      "languages": [
-        "python",
-        "typescript"
-      ],
-      "categories": [
-        "devops",
-        "cloud",
-        "productivity",
-        "ci"
-      ]
+      "message": "Deixe-nos uma estrelinha ⭐ PRs são bem-vindas. Discord: https://discord.gg/5KphsWxHeJ",
+      "languages": ["python", "typescript"],
+      "categories": ["devops", "cloud", "productivity", "ci"]
     }
   ]
 }

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -6,7 +6,7 @@
       "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀",
       "madeInBrazil": true,
       "isAuthor": true,
-      "message": "Deixe uma estrelinha ⭐ e envie PRs para o repo do Devopness :-). Contrataremos freelas (e equipe permanente 🤞🏽) com prioridade para quem já tem seu nome aqui https://github.com/devopness/devopness/graphs/contributors :-)",
+      "message": "Deixe uma estrelinha ⭐ e envie PRs para o repo do Devopness :-). Veja o produto em ação em https://www.youtube.com/@devopness/videos Contrataremos freelas (e equipe permanente 🤞🏽) com prioridade para quem já tem seu nome aqui https://github.com/devopness/devopness/graphs/contributors :-)",
       "languages": [
         "javascript",
         "typescript",

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -4,7 +4,7 @@
     {
       "repository": "https://github.com/devopness/devopness",
       "name": "Devopness",
-      "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀 https://www.youtube.com/@devopness/videos",
+      "description": "DevOps Happiness: for AI Agents & Humans. Deploy any app to any cloud & provision cloud infra in minutes. Fast, simple, cloud-native 🚀",
       "madeInBrazil": true,
       "isAuthor": true,
       "message": "Deixe-nos uma estrelinha ⭐ PRs são bem-vindas. Discord: https://discord.gg/5KphsWxHeJ",

--- a/static/maintainers/jfoliveira/projects.json
+++ b/static/maintainers/jfoliveira/projects.json
@@ -6,25 +6,16 @@
       "description": "Devopness: automated DevOps for AI Agents & Humans. Provision infra and deploy any software to any cloud, in minutes 🚀",
       "madeInBrazil": true,
       "isAuthor": true,
-      "message": "Deixe uma estrelinha ⭐ e envie PRs para o repo do Devopness :-). Veja o produto em ação em https://www.youtube.com/@devopness/videos Contrataremos freelas (e equipe permanente 🤞🏽) com prioridade para quem já tem seu nome aqui https://github.com/devopness/devopness/graphs/contributors :-)",
+      "message": "Deixe-nos uma estrelinha ⭐ e PRs são bem-vindas :-). Veja o produto em ação em https://www.youtube.com/@devopness/videos",
       "languages": [
-        "javascript",
-        "typescript",
         "python",
-        "ruby",
-        "shell"
+        "typescript"
       ],
       "categories": [
-        "ai",
-        "api",
-        "career",
-        "ci",
-        "cli",
-        "cloud",
         "devops",
-        "git",
+        "cloud",
         "productivity",
-        "tool"
+        "ci"
       ]
     }
   ]


### PR DESCRIPTION
### Projetos

- [x] adiciona o projeto [Devopness](https://www.devopness.com/)

### Geral
- [x] adiciona a categoria `cloud`
- [x] renomeia as traduções de "_contributor_", que estava variando entre `"contribuinte"` e `"contribuidor"`
  - Padronizado como **colaborador**, em alinhamento com a documentação do GitHub em PT-BR [1], que se refere a _contributor_ como `colaborador`
    > Nota: ao menos na minha cabeça `contribuinte` é o pagador de imposto, então bora aliviar os impostos de quem já tá colaborando em projetos open source :-) 

[1] https://docs.github.com/pt/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/a9293d0b-301c-4c78-8e87-78897510daf4" />


