### PR TITLE
fix: use GitHub username when user has no name

### DIFF
--- a/src/contexts/Maintainer.tsx
+++ b/src/contexts/Maintainer.tsx
@@ -34,7 +34,10 @@ export const Provider: FC<ContextType & { children: ReactNode }> = ({
       value={{
         title,
         description,
-        maintainer,
+        maintainer: {
+          ...maintainer,
+          name: maintainer.name || maintainer.username,
+        },
       }}
     >
       {children}

--- a/src/pages/new/_form/_maintaner.tsx
+++ b/src/pages/new/_form/_maintaner.tsx
@@ -59,7 +59,7 @@ export const Maintainer: FC = () => {
 
         if (typeof name === 'string')
           toast.success(
-            `Obrigado por estar aqui, ${name.split(' ').shift()} ✨`
+            `Obrigado por estar aqui, ${(name || username).split(' ').shift()} ✨`
           );
       } catch {}
     });

--- a/tools/generate-maintainers.mts
+++ b/tools/generate-maintainers.mts
@@ -36,7 +36,7 @@ const getGitHubUserName = async (username: string) => {
 
   const { name, bio, location, blog } = await response.json();
 
-  return { name, bio, location, blog };
+  return { name: name || username, bio, location, blog };
 };
 
 for (const file of files) {


### PR DESCRIPTION
No _PR_ #40, foi adicionado um usuário do **GitHub** que não possui o nome definido na plataforma _(pensava ser um campo obrigatório do **GitHub** até então)_.

Quando isso ocorrer, adicionei um suporte para que o próprio _username_ do **GitHub** seja exibido.

> cc: @jfoliveira 