### PR TITLE
fix: revert "colaborador" to "contribuidor"

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -20,7 +20,7 @@
 
 > [!NOTE]
 >
-> - <sup>1</sup> Por ativo, o projeto precisa estar pronto para receber Issues ou Pull Requests de possíveis colaboradores e estar aberto a discussões.
+> - <sup>1</sup> Por ativo, o projeto precisa estar pronto para receber Issues ou Pull Requests de possíveis contribuidores e estar aberto a discussões.
 > - <sup>2</sup> "Aceitar" é diferente de "mesclar". Se o projeto é feito para a comunidade _open source_, ele deve estar aberto para debater ideias que usuários proponham e corrigir _bugs_ reportados, por exemplo.
 > - <sup>3</sup> O **GitHub** busca pelo arquivo `LICENSE` e também por arquivos que comecem por `LICENSE-___`, ambos no diretório raiz do repositório. Caso o **GitHub** não encontre a licença, o projeto irá falhar nos testes automatizados.
 

--- a/docs/SCORE.md
+++ b/docs/SCORE.md
@@ -17,11 +17,11 @@ Por exemplo, um projeto com poucas estrelas, mas que tenha contribuições de ou
 
 Projeto com uma comunidade forte:
 
-- Com **15** colaboradores, **0** instalações ou downloads, **20** forks, **55** estrelas, **5** issues abertas e **45** issues fechadas conseguiria quebrar a barreira dos **200** pontos.
+- Com **15** contribuidores, **0** instalações ou downloads, **20** forks, **55** estrelas, **5** issues abertas e **45** issues fechadas conseguiria quebrar a barreira dos **200** pontos.
 
 Projeto com alto impacto, mas baixa popularidade:
 
-- Com **6** colaboradores, **20.000** instalações ou downloads mensais, **3** forks, **16** estrelas, **0** issues abertas, **28** issues fechadas e **200** dependências diretas do repositório conseguiria quebrar a barreira dos **200** pontos.
+- Com **6** contribuidores, **20.000** instalações ou downloads mensais, **3** forks, **16** estrelas, **0** issues abertas, **28** issues fechadas e **200** dependências diretas do repositório conseguiria quebrar a barreira dos **200** pontos.
 
 **Como é possível um projeto ter tantos downloads e não ser popular?**
 
@@ -43,9 +43,9 @@ Para um projeto que dependa exclusivamente da popularidade, ele precisaria obter
 
 <br />
 
-As pontuações por senso de comunidade envolvem números de colaboradores com _commits_ na _branch_ principal do repositório e também através da intenção de contribuição _(forks)_:
+As pontuações por senso de comunidade envolvem números de contribuidores com _commits_ na _branch_ principal do repositório e também através da intenção de contribuição _(forks)_:
 
-- Cada colaborador com _commits_ na _branch_ principal equivale a **5** pontos.
+- Cada contribuidor com _commits_ na _branch_ principal equivale a **5** pontos.
   - Atualmente, essa conta também inclui _bots_, não por intenção, mas por limitação de automação.
 - Cada intenção de contribuição _(forks)_ equivalem a **2** pontos.
 - É obrigatório que o projeto tenha uma licença transparente e identificada pelo **GitHub**.

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -211,7 +211,7 @@ export const Project: FC<ProcessedProject> = ({
                   </tr>
 
                   <tr>
-                    <td>Colaboradores:</td>
+                    <td>Contribuidores:</td>
                     <td>
                       <SafeLink to={`${url}/graphs/contributors`}>
                         <HeartHandshake />

--- a/src/pages/_dynamic/maintainer/_ld/faqs.ts
+++ b/src/pages/_dynamic/maintainer/_ld/faqs.ts
@@ -48,7 +48,7 @@ export const ldFaqs = (options: Props) => {
             ? [
                 {
                   name: `Quem criou o ${project.name}?`,
-                  text: `${project.name} foi criado por ${name}, colaborador brasileiro ativo da comunidade open source.`,
+                  text: `${project.name} foi criado por ${name}, contribuidor brasileiro ativo da comunidade open source.`,
                 },
               ]
             : []),

--- a/src/pages/_dynamic/maintainer/_project.tsx
+++ b/src/pages/_dynamic/maintainer/_project.tsx
@@ -107,7 +107,7 @@ export const Project: FC<Props> = (project) => {
         </p>
         <p>
           — O repositório do projeto conta com{' '}
-          <strong>{stats.contributors.label}</strong> colaborador
+          <strong>{stats.contributors.label}</strong> contribuidor
           {stats.contributors.value > 1 && 'es'}
           {stats.repositoryDependents.value > 0 && (
             <>

--- a/src/pages/calculator.tsx
+++ b/src/pages/calculator.tsx
@@ -344,7 +344,7 @@ export default (): ReactNode => {
                   <table>
                     <tbody>
                       <tr>
-                        <td>Colaboradores</td>
+                        <td>Contribuidores</td>
                         <td>
                           <HeartHandshake />
                           {stats?.contributors?.label || 0}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -347,7 +347,7 @@ export default (): ReactNode => {
                   Como um projeto aberto e criado pela comunidade para a
                   comunidade, todos os{' '}
                   <SafeLink to='https://github.com/wellwelwel/awesomeyou/graphs/contributors'>
-                    <strong>colaboradores</strong>
+                    <strong>contribuidores</strong>
                   </SafeLink>{' '}
                   fazem parte do projeto 🤝
                 </p>

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -67,7 +67,7 @@ const Footer = (): ReactNode => {
           </p>
           <p>
             Os dados vêm de APIs públicas e das próprias informações fornecidas
-            pelos colaboradores ao incluirem projetos e mantenedores.
+            pelos contribuidores ao incluirem projetos e mantenedores.
           </p>
           <p>
             Você pode encontrar nosso código fonte e contribuir através do{' '}


### PR DESCRIPTION
No _PR_ #40, foram trocadas todas as menções de "contribuidores" para "colaboradores". Conforme explicado no https://github.com/wellwelwel/awesomeyou/pull/40#issuecomment-2919984826, estou revertendo essa alteração e padronizando todas as menções para "contribuidores" ou "contribuidor".

**Agradecimentos:**

- @jfoliveira